### PR TITLE
Change strftime argument to resolve compatibility issues on Windows

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -115,4 +115,4 @@ def timestamp():
     return delta.total_seconds()
 
 def date():
-    return datetime.now().strftime('%F')
+    return datetime.now().strftime('%Y-%m-%d')


### PR DESCRIPTION
```python
datetime.now().strftime('%Y-%m-%d')
```
works fine on both *nix and Windows, while

```python
datetime.now().strftime('%F') 	
```
gives `ValueError: Invalid format string` on Windows.

Both return a string in the format of "year-month-day"