### PR TITLE
Typo in import

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -1,4 +1,4 @@
-from models import User, get_todays_recent_posts
+from .models import User, get_todays_recent_posts
 from flask import Flask, request, session, redirect, url_for, render_template, flash
 
 app = Flask(__name__)


### PR DESCRIPTION
Add dot to 'import .model' (was 'import model'). Without dot this isn't working in python 3.5